### PR TITLE
change namespace for scripts to pylinkirc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,14 +38,15 @@ unidecode = "^1.3.6"
 pytest = "*"
 autoflake8 = "*"
 ipython = "*"
+monkeytype = "^22.2.0"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-ircd = "pybrokenirc.launcher:main"
-ircd-mkpasswd = "pybrokenirc.mkpasswd:main"
+ircd = "pylinkirc.launcher:main"
+ircd-mkpasswd = "pylinkirc.mkpasswd:main"
 
 [tool.autopep8]
 max_line_length = 120


### PR DESCRIPTION
the executables need to use the old namespace for now, the package is just copied as is 'pylinkirc' under the src/ directory. 